### PR TITLE
API provides article categories

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-18
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
@@ -208,4 +209,4 @@ RUBY VERSION
    ruby 3.0.0p0
 
 BUNDLED WITH
-   2.3.7
+   2.3.10

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -13,6 +13,8 @@ class Api::ArticlesController < ApplicationController
 
   def create
     new_article = Article.create(params[:article].permit!)
+    binding.pry
+    # Here you need to check if the article was created or not
     render json: { article: new_article }, status: 201
   end
 

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -1,8 +1,9 @@
 class Api::ArticlesController < ApplicationController
 
   def index
-    articles = Article.all
-    render json: { articles: articles }
+    categories = Category.all.includes(:articles)
+    response = serialize_categories(categories)
+    render json: { articles: response }
   end
 
   def show
@@ -20,4 +21,13 @@ class Api::ArticlesController < ApplicationController
   def article_params
     params[:article].permit(:title, :body)
   end
+
+  def serialize_categories(categories)
+    response = {}
+    categories.each do |category|
+      response[category.name.downcase] = category.articles.as_json
+    end
+    response
+  end
+
 end

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -10,4 +10,14 @@ class Api::ArticlesController < ApplicationController
     render json: { article: article }
   end
 
+  def create
+    new_article = Article.create(params[:article].permit!)
+    render json: { article: new_article }, status: 201
+  end
+
+  private
+
+  def article_params
+    params[:article].permit(:title, :body)
+  end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,2 +1,3 @@
 class Article < ApplicationRecord
+  belongs_to :category
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,3 @@
+class Category < ApplicationRecord
+  has_many :articles
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,9 @@ Bundler.require(*Rails.groups)
 
 module DgmsNewsApi
   class Application < Rails::Application
+    initializer(:remove_activestorage_routes, after: :add_routing_paths) do |app|
+      app.routes_reloader.paths.delete_if { |path| path =~ /activestorage|actionmailbox/ }
+    end
     config.load_defaults 6.1
     config.api_only = true
     config.middleware.insert_before 0, Rack::Cors do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   namespace :api do
-    resources :articles, only: %i[index show]
+    resources :articles, only: %i[index show create]
   end
 end

--- a/db/migrate/20220402094225_create_categories.rb
+++ b/db/migrate/20220402094225_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[6.1]
+  def change
+    create_table :categories do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220402095818_add_category_to_articles.rb
+++ b/db/migrate/20220402095818_add_category_to_articles.rb
@@ -1,0 +1,5 @@
+class AddCategoryToArticles < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :articles, :category, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_27_203228) do
+ActiveRecord::Schema.define(version: 2022_04_02_095818) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,15 @@ ActiveRecord::Schema.define(version: 2022_03_27_203228) do
     t.string "author"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "category_id", null: false
+    t.index ["category_id"], name: "index_articles_on_category_id"
   end
 
+  create_table "categories", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  add_foreign_key "articles", "categories"
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :article do
-    title { "MyString" }
-    body { "MyText" }
+    title { "News about coding" }
+    body { "Lorem ipsum..." }
     author { "MyString" }
     category
   end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     title { "MyString" }
     body { "MyText" }
     author { "MyString" }
+    category
   end
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :category do
+    name { "MyString" }
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_db_column(:author).of_type(:string) }
   end
 
+  describe 'Associations' do
+    it { is_expected.to belong_to :category}  
+  end
+
   describe 'Factory' do
     it 'is expected to be valid' do
       expect(create(:article)).to be_valid

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Category, type: :model do
+
+  describe 'Databese' do
+    it { is_expected.to have_db_column(:name).of_type(:string) }
+  end
+
+  describe 'Associations' do
+    it { is_expected.to have_many :articles }
+  end
+
+  describe 'Factory' do
+    it 'is expected to be valid' do
+      expect(create(:category)).to be_valid
+    end
+  end
+
+end

--- a/spec/requests/api/articles/create_spec.rb
+++ b/spec/requests/api/articles/create_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe 'POST /api/articles' do
+
+  before do
+    post '/api/articles', params: {
+      article: { title: 'News about coding', body: 'Lorem ipsum...' }
+    }
+
+    @article = Article.last
+    # without ... expect(Article).not_to be nil
+  end
+
+  subject { response }
+
+  it { is_expected.to have_http_status 201 }
+
+  it 'is expected to create an instance of an Article' do
+    expect(@article).not_to be nil
+  end
+
+  it 'is expected to have a title' do
+    expect(@article.title).to eq 'News about coding'
+  end
+
+  it 'is expected to have a body' do
+    expect(@article.body).to eq 'Lorem ipsum...'
+  end
+
+end

--- a/spec/requests/api/articles/create_spec.rb
+++ b/spec/requests/api/articles/create_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'POST /api/articles' do
     }
 
     @article = Article.last
-    # without ... expect(Article).not_to be nil
+    
   end
 
   subject { response }

--- a/spec/requests/api/articles/create_spec.rb
+++ b/spec/requests/api/articles/create_spec.rb
@@ -1,17 +1,15 @@
 RSpec.describe 'POST /api/articles' do
-  let(:sports_category) { create(:category, name: 'Sports')}
-  let(:business_category) { create(:category, name: 'Business')}
-  let!(:sports_articles) { create_list(:article, 5, category: sports_category) }
-  let!(:business_articles) { create_list(:article, 5, category: business_category) }
-
+  let(:sports_category) { create(:category, name: 'Sports') }
+  # let(:business_category) { create(:category, name: 'Business') }
+  # let!(:sports_articles) { create_list(:article, 5, category: sports_category) }
+  # let!(:business_articles) { create_list(:article, 5, category: business_category) }
 
   before do
     post '/api/articles', params: {
-      article: { title: 'News about coding', body: 'Lorem ipsum...' }
+      article: { title: 'News about Sports', body: 'Lorem ipsum...' }
     }
 
     @article = Article.last
-    
   end
 
   subject { response }
@@ -19,15 +17,15 @@ RSpec.describe 'POST /api/articles' do
   it { is_expected.to have_http_status 201 }
 
   it 'is expected to create an instance of an Article' do
+    binding.pry
     expect(@article).not_to be nil
   end
 
   it 'is expected to have a title' do
-    expect(@article.title).to eq 'News about coding'
+    expect(@article.title).to eq 'News about Sports'
   end
 
   it 'is expected to have a body' do
     expect(@article.body).to eq 'Lorem ipsum...'
   end
-
 end

--- a/spec/requests/api/articles/create_spec.rb
+++ b/spec/requests/api/articles/create_spec.rb
@@ -1,4 +1,9 @@
 RSpec.describe 'POST /api/articles' do
+  let(:sports_category) { create(:category, name: 'Sports')}
+  let(:business_category) { create(:category, name: 'Business')}
+  let!(:sports_articles) { create_list(:article, 5, category: sports_category) }
+  let!(:business_articles) { create_list(:article, 5, category: business_category) }
+
 
   before do
     post '/api/articles', params: {

--- a/spec/requests/api/articles/index_spec.rb
+++ b/spec/requests/api/articles/index_spec.rb
@@ -1,5 +1,8 @@
 RSpec.describe 'GET /api/articles', type: :request do
-  let!(:articles) { create_list(:article, 5) }
+  let(:sports_category) { create(:category, name: 'Sports')}
+  let(:business_category) { create(:category, name: 'Business')}
+  let!(:sports_articles) { create_list(:article, 5, category: sports_category) }
+  let!(:business_articles) { create_list(:article, 5, category: business_category) }
 
   before do
     get '/api/articles'
@@ -9,7 +12,16 @@ RSpec.describe 'GET /api/articles', type: :request do
 
   it { is_expected.to have_http_status 200 }
 
-  it 'is expected to return a collection of 5 articles' do
-    expect(response_json['articles'].size).to eq 5
+  # it 'is expected to return a collection of 5 articles' do
+  #   expect(response_json['articles'].size).to eq 5
+  # end
+
+  it 'is expected to return articles grouped by category' do
+    expect(response_json['articles'].keys).to match ['sports', 'business']
   end
+
+  it 'is expected to include 5 articles in the sports category' do
+    expect(response_json['articles']['sports'].size).to eq 5
+  end
+
 end

--- a/temp_article_resp.json
+++ b/temp_article_resp.json
@@ -1,0 +1,25 @@
+// NEW WAY
+
+{
+  "articles": {
+    "sports": [
+      {"id": 1, "title": "Sports 1", "body": "Sports 1 body"},
+      {"id": 2, "title": "Sports 2", "body": "Sports 2 body"},
+      {"id": 3, "title": "Sports 3", "body": "Sports 3 body"}
+    ],
+    "business": [
+      {"id": 1, "title": "Business 1", "body": "Business 1 body"},
+      {"id": 2, "title": "Business 2", "body": "Business 2 body"},
+      {"id": 3, "title": "Business 3", "body": "Business 3 body"}
+    ]
+  }
+}
+
+// OLD WAY
+{
+  "articles": [
+    {"id": 1, "title": "Sports 1", "body": "Sports 1 body"},
+    {"id": 2, "title": "Sports 2", "body": "Sports 2 body"},
+    {"id": 3, "title": "Sports 3", "body": "Sports 3 body"}
+  ]
+}


### PR DESCRIPTION
Link to PT: https://www.pivotaltracker.com/story/show/181571071

User Story:
```
As a developer
In order to see relevant news
I would like to see articles sorted into categories
```
![article_create_categories_fixed](https://user-images.githubusercontent.com/15264325/161386265-db327569-9b25-4aee-9220-3b1c015e9d6e.png)

