### PR TITLE
Chore: API stores subscription information on users

### DIFF
--- a/app/controllers/api/subscriptions_controller.rb
+++ b/app/controllers/api/subscriptions_controller.rb
@@ -1,0 +1,11 @@
+class Api::SubscriptionsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    user = User.find(params[:user][:id])
+    user.subscribed = true
+    user.save
+
+    render json: { message: 'You are now subscribed.' }, status: 201
+  end
+end

--- a/app/controllers/api/subscriptions_controller.rb
+++ b/app/controllers/api/subscriptions_controller.rb
@@ -2,9 +2,7 @@ class Api::SubscriptionsController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    user = User.find(params[:user][:id])
-    user.subscribed = true
-    user.save
+    current_user.update(subscribed: true)
 
     render json: { message: 'You are now subscribed.' }, status: 201
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'api/auth'
   namespace :api do
     resources :articles, only: %i[index show create]
+    resources :subscriptions, only: :create
   end
 end

--- a/db/migrate/20220413093207_add_subscription_to_user.rb
+++ b/db/migrate/20220413093207_add_subscription_to_user.rb
@@ -1,0 +1,5 @@
+class AddSubscriptionToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :subscribed, :bool, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_11_200841) do
+ActiveRecord::Schema.define(version: 2022_04_13_093207) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 2022_04_11_200841) do
     t.json "tokens"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "subscribed", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/requests/api/subscriptions/create_spec.rb
+++ b/spec/requests/api/subscriptions/create_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe 'POST /api/subscriptions', type: :request do
 
   subject { response }
 
-  describe 'as a authenticated user, when subscribing' do
+  describe 'as a authenticated user' do
     before do
-      post '/api/subscriptions', params: { user: { id: user.id } }, headers: credentials
+      post '/api/subscriptions', headers: credentials
     end
 
     it { is_expected.to have_http_status 201 }
@@ -16,13 +16,13 @@ RSpec.describe 'POST /api/subscriptions', type: :request do
     end
 
     it 'is expected that the user subscription status is changed' do
-      expect(User.last.subscribed).to eq true
+      expect(user.reload.subscribed).to eq true
     end
   end
 
-  describe 'as an unauthenticated user, when subsribing' do
+  describe 'as an unauthenticated user' do
     before do
-      post '/api/subscriptions', params: { user: { id: user.id } }, headers: nil
+      post '/api/subscriptions', headers: nil
     end
 
     it { is_expected.to have_http_status 401 }
@@ -32,7 +32,7 @@ RSpec.describe 'POST /api/subscriptions', type: :request do
     end
 
     it 'is expected not to change the user subscription status' do
-      expect(User.last.subscribed).to eq false
+      expect(user.reload.subscribed).to eq false
     end
   end
 end

--- a/spec/requests/api/subscriptions/update_spec.rb
+++ b/spec/requests/api/subscriptions/update_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe 'POST /api/subscriptions', type: :request do
+  let(:user) { create(:user) }
+  let(:credentials) { user.create_new_auth_token }
+
+  subject { response }
+
+  describe 'as a authenticated user, when subscribing' do
+    before do
+      post '/api/subscriptions', params: { user: { id: user.id } }, headers: credentials
+    end
+
+    it { is_expected.to have_http_status 201 }
+
+    it 'is expected to return a message that subscription status was changed' do
+      expect(response_json['message']).to eq 'You are now subscribed.'
+    end
+
+    it 'is expected that the user subscription status is changed' do
+      expect(User.last.subscribed).to eq true
+    end
+  end
+
+  describe 'as an unauthenticated user, when subsribing' do
+    before do
+      post '/api/subscriptions', params: { user: { id: user.id } }, headers: nil
+    end
+
+    it { is_expected.to have_http_status 401 }
+
+    it 'is expected to return an error message' do
+      expect(response_json['errors'][0]).to eq 'You need to sign in or sign up before continuing.'
+    end
+
+    it 'is expected not to change the user subscription status' do
+      expect(User.last.subscribed).to eq false
+    end
+  end
+end


### PR DESCRIPTION
Link to PT: https://www.pivotaltracker.com/story/show/181884772

```
As an API
In order to prepare for monetization for the platform
I would like to provide an endpoint to register if the user is subscribed
```